### PR TITLE
ci: fix branch name to avoid breaking change

### DIFF
--- a/.github/workflows/build_ui.yaml
+++ b/.github/workflows/build_ui.yaml
@@ -38,8 +38,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: "${{ github.ref_name }}-latest"
-        name: "Release ${{ github.ref_name }}-latest"
+        tag_name: "${{ github.ref_name }}-LATEST"
+        name: "Release ${{ github.ref_name }}-LATEST"
         body: |
           Release of the DevOps Stack's Antora UI `ui-bundle.zip` for ${{ github.ref_name }}
         draft: false


### PR DESCRIPTION
It was shortsighted of me that in the revamping of this UI I changed the name of the release given by the workflow. Since this CI deletes the older releases, it means that the current antora-playbook.yaml in the devops-stack will point to ui bundle that no longer exists. This commit will revert that.